### PR TITLE
Access system and save RAM using Libretro API

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -237,6 +237,8 @@ static bool TestMagic(const char *name, MDFNFILE *fp)
  return(true);
 }
 
+static uint32 SRAMSize;
+
 static int Load(const char *name, MDFNFILE *fp)
 {
    uint32 real_rom_size;
@@ -273,7 +275,7 @@ static int Load(const char *name, MDFNFILE *fp)
       printf(_("Developer: %s (0x%02x)\n"), developer_name, header[0]);
    }
 
-   uint32 SRAMSize = 0;
+   SRAMSize = 0;
    eeprom_size = 0;
 
    switch(header[5])
@@ -329,7 +331,7 @@ static int Load(const char *name, MDFNFILE *fp)
 
 static void CloseGame(void)
 {
-   WSwan_MemoryKill(); // saves sram/eeprom
+   WSwan_MemoryKill();
 
    WSwan_SoundKill();
 
@@ -1026,13 +1028,43 @@ bool retro_unserialize(const void *data, size_t size)
    return MDFNSS_LoadSM(&st, 0, 0);
 }
 
-void *retro_get_memory_data(unsigned)
+void *retro_get_memory_data(unsigned type)
 {
+   switch (type)
+   {
+      case RETRO_MEMORY_SAVE_RAM:
+         if (eeprom_size)
+            return (uint8_t*)wsEEPROM;
+         else if (SRAMSize)
+            return wsSRAM;
+         else
+            return NULL;
+      case RETRO_MEMORY_SYSTEM_RAM:
+         return (uint8_t*)wsRAM;
+      default:
+         break;
+   }
+
    return NULL;
 }
 
-size_t retro_get_memory_size(unsigned)
+size_t retro_get_memory_size(unsigned type)
 {
+   switch (type)
+   {
+      case RETRO_MEMORY_SAVE_RAM:
+         if (eeprom_size)
+            return eeprom_size;
+         else if (SRAMSize)
+            return SRAMSize;
+         else
+            return 0;
+      case RETRO_MEMORY_SYSTEM_RAM:
+         return wsRAMSize;
+      default:
+         break;
+   }
+
    return 0;
 }
 

--- a/mednafen/wswan/wswan-memory.cpp
+++ b/mednafen/wswan/wswan-memory.cpp
@@ -37,7 +37,7 @@ static bool SkipSL; // Skip save and load
 
 uint32 wsRAMSize;
 uint8 wsRAM[65536];
-static uint8 *wsSRAM = NULL;
+uint8 *wsSRAM = NULL;
 
 uint8 *wsCartROM;
 static uint32 sram_size;
@@ -466,19 +466,6 @@ void WSwan_MemorySetRegister(const unsigned int id, uint32 value)
 
 void WSwan_MemoryKill(void)
 {
-   if((sram_size || eeprom_size) && !SkipSL)
-   {
-      std::vector<PtrLengthPair> EvilRams;
-
-      if(eeprom_size)
-         EvilRams.push_back(PtrLengthPair(wsEEPROM, eeprom_size));
-
-      if(sram_size)
-         EvilRams.push_back(PtrLengthPair(wsSRAM, sram_size));
-
-      MDFN_DumpToFile(MDFN_MakeFName(MDFNMKF_SAV, 0, "sav").c_str(), 6, EvilRams);
-   }
-
    if(wsSRAM)
       free(wsSRAM);
    wsSRAM = NULL;
@@ -517,21 +504,6 @@ void WSwan_MemoryInit(bool lang, bool IsWSC, uint32 ssize, bool SkipSaveLoad)
    {
       wsSRAM = (uint8*)malloc(sram_size);
       memset(wsSRAM, 0, sram_size);
-   }
-
-   if((sram_size || eeprom_size) && !SkipSL)
-   {
-      FILE *savegame_fp;
-
-      savegame_fp = gzopen(MDFN_MakeFName(MDFNMKF_SAV, 0, "sav").c_str(), "rb");
-      if(savegame_fp)
-      {
-         if(eeprom_size)
-            gzread(savegame_fp, wsEEPROM, eeprom_size);
-         if(sram_size)
-            gzread(savegame_fp, wsSRAM, sram_size);
-         gzclose(savegame_fp);
-      }
    }
 
    MDFNMP_AddRAM(wsRAMSize, 0x00000, wsRAM);

--- a/mednafen/wswan/wswan-memory.h
+++ b/mednafen/wswan/wswan-memory.h
@@ -13,6 +13,8 @@ extern uint8 wsRAM[65536];
 extern uint8 *wsCartROM;
 extern uint32 eeprom_size;
 extern uint8 wsEEPROM[2048];
+extern uint8 *wsSRAM;
+extern uint32 wsRAMSize;
 
 uint8 WSwan_readmem20(uint32);
 void WSwan_writemem20(uint32 address,uint8 data);


### PR DESCRIPTION
Based on rom header, https://github.com/libretro/beetle-wswan-libretro/blob/master/libretro.cpp#L279, the rom either uses sram (wsSRAM) or eeprom (wsEEPROM) for save data. Exposing these variables seems enough to be able to access them from libretro API.

Save and load tested under Archlinux-x64 and Windows7-x64(by @Tatsuya79 )