### PR TITLE
Update libretro.cpp: Add input descriptor

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -569,6 +569,7 @@ bool retro_load_game(const struct retro_game_info *info)
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "A" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "B" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Start" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Rotate screen + active D-Pad" },
 
       { 0 },
    };


### PR DESCRIPTION
The Rotate screen and the active D-Pad input mapped to the Select button was missing a descriptor.

Compiled and tested successfully on Windows 10 x64.