### PR TITLE
Added .pc2 file extension support

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -421,6 +421,7 @@ static const FileExtensionSpecStruct KnownExtensions[] =
  { ".ws", "WonderSwan ROM Image" },
  { ".wsc", "WonderSwan Color ROM Image" },
  { ".wsr", "WonderSwan Music Rip" },
+ { ".pc2", "Benesse Pocket Challenge 2" },
  { NULL, NULL }
 };
 


### PR DESCRIPTION
This should allow emulation of Benesse Pocket Challenge 2 files as they can be emulated when renamed TITLE.ws or TITLE.wsc