### PR TITLE
Fixed off-by-1 bugs in window coordinate evaluation, per tip from trap15.

### DIFF
--- a/mednafen/wswan/gfx.cpp
+++ b/mednafen/wswan/gfx.cpp
@@ -426,7 +426,7 @@ void wsScanline(uint16 *target)
 
          if(windowtype == 0x20) // Display FG only inside window
          {
-            if((wsLine >= FGy0) && (wsLine < FGy1))
+            if((wsLine >= FGy0) && (wsLine <= FGy1))
                for(j = FGx0; j <= FGx1 && j < 224; j++)
                   in_window[7 + j] = 1;
          }
@@ -434,7 +434,7 @@ void wsScanline(uint16 *target)
          {
             for(j = 0; j < 224; j++)
             {
-               if(!(j >= FGx0 && j < FGx1) || !((wsLine >= FGy0) && (wsLine < FGy1)))
+               if(!(j >= FGx0 && j <= FGx1) || !((wsLine >= FGy0) && (wsLine < FGy1)))
                   in_window[7 + j] = 1;
             }
          }
@@ -502,8 +502,8 @@ void wsScanline(uint16 *target)
       if(DispControl & 0x08)
       {
          memset(in_window, 0, sizeof(in_window));
-         if((wsLine >= SPRy0) && (wsLine < SPRy1))
-            for(j = SPRx0; j < SPRx1 && j < 256; j++)
+         if((wsLine >= SPRy0) && (wsLine <= SPRy1))
+            for(j = SPRx0; j <= SPRx1 && j < 256; j++)
                in_window[7 + j] = 1;
       }
       else


### PR DESCRIPTION
The fix comes from Mednafen 0.9.41.

One affected game is Klonoa : there's a straight grey line over the game's HUD.
(Most noticeable on the hearts in the bottom left when ingame)
This fixes this issue.

![klonoa-before](https://user-images.githubusercontent.com/8717966/55403888-5c880300-5546-11e9-98f5-1286a6d9beb7.png)

![klonoa-after](https://user-images.githubusercontent.com/8717966/55403896-614cb700-5546-11e9-83bb-c13110231bd6.png)

