### PR TITLE
Fix 'double free' crash when closing content

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -350,9 +350,11 @@ void retro_unload_game()
 
    if (surf)
    {
-      free(surf->pixels);
+      if (surf->pixels)
+         free(surf->pixels);
       free(surf);
    }
+   surf = NULL;
 }
 
 static void update_input(void)


### PR DESCRIPTION
At present, the core crashes when closing content due to a double free error.

This PR fixes the issue.