### PR TITLE
Add software-based display rotation fallback + 'Rotate Display' core option

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -50,12 +50,23 @@ extern "C" {
 
 struct retro_core_option_definition option_defs_us[] = {
    {
-      "wswan_rotate_keymap",
-      "Rotate button mappings",
-      "",
+      "wswan_rotate_display",
+      "Rotate Display",
+      "Rotate the console screen to achieve the correct layout of 'portrait' oriented games on a conventional (landscape) display. 'Manual' enables rotation via the controller (default button: SELECT).",
       {
-         { "auto",  NULL },
-         { "disabled",  NULL },
+         { "manual",  "Manual" },
+         { "enabled", NULL },
+         { NULL, NULL},
+      },
+      "manual",
+   },
+   {
+      "wswan_rotate_keymap",
+      "Rotate Button Mappings",
+      "'Auto' adjusts button mapping to match the current display rotation.",
+      {
+         { "auto",     "Auto" },
+         { "disabled", NULL },
          { "enabled",  NULL },
          { NULL, NULL},
       },
@@ -66,11 +77,11 @@ struct retro_core_option_definition option_defs_us[] = {
       "Sound Output Sample Rate",
       "Slightly higher quality or higher performance.",
       {
-         { "11025", NULL },
-         { "22050", NULL },
-         { "44100", NULL },
-         { "48000", NULL },
-         { "96000", NULL },
+         { "11025",  NULL },
+         { "22050",  NULL },
+         { "44100",  NULL },
+         { "48000",  NULL },
+         { "96000",  NULL },
          { "192000", NULL },
          { "384000", NULL },
          { NULL, NULL },


### PR DESCRIPTION
At present, the display rotation functionality of this core relies on frontend gfx driver rotation support. Unfortunately, a number of platforms simply do not have this, rendering portrait-oriented games rather unplayable...

This PR adds a simple fallback - if the current frontend doesn't support 'hardware based' rotation (via the gfx driver), then the video buffer is rotated in software. The buffer is small enough that this is a trivial operation - tested on an RG350M OpenDingux device, there is no discernable performance impact when rotation is enabled.

In addition, this PR adds a new `Rotate Display` core option. This allows the rotation to be forced 'on' for games that permanently have a portrait layout (i.e. saves having to manually press RetroPad 'select' each time they are launched).