### PR TITLE
Fix v30mz regression (again)

### DIFF
--- a/mednafen/wswan/v30mz.c
+++ b/mednafen/wswan/v30mz.c
@@ -808,8 +808,13 @@ static void DoOP(uint8 opcode)
             }
          } OP_EPILOGUE;
 
-         OP( 0xd4, i_aam    ) { I.regs.b[AH] = I.regs.b[AL] / 10; I.regs.b[AL] %= 10; SetSZPF_Word(I.regs.w[AW]); CLK(17); } OP_EPILOGUE;
-         OP( 0xd5, i_aad    ) { I.regs.b[AL] = I.regs.b[AH] * 10 + I.regs.b[AL]; I.regs.b[AH] = 0; SetSZPF_Byte(I.regs.b[AL]); CLK(6); } OP_EPILOGUE;
+         /* Warning: Do not modify this code, or everything
+          * will break
+          * (ignore any "variable 'mult' set but not used"
+          * compiler warnings; 'FETCH' is a non-trivial
+          * macro, and is absolutely required) */
+         OP( 0xd4, i_aam    ) { uint32 mult=FETCH; mult=0; I.regs.b[AH] = I.regs.b[AL] / 10; I.regs.b[AL] %= 10; SetSZPF_Word(I.regs.w[AW]); CLK(17); } OP_EPILOGUE;
+         OP( 0xd5, i_aad    ) { uint32 mult=FETCH; mult=0; I.regs.b[AL] = I.regs.b[AH] * 10 + I.regs.b[AL]; I.regs.b[AH] = 0; SetSZPF_Byte(I.regs.b[AL]); CLK(6); } OP_EPILOGUE;
          OP( 0xd6, i_setalc ) { I.regs.b[AL] = (CF)?0xff:0x00; CLK(3);  } OP_EPILOGUE;
          OP( 0xd7, i_trans  ) { uint32 dest = (I.regs.w[BW]+I.regs.b[AL])&0xffff; I.regs.b[AL] = GetMemB(DS0, dest); CLK(5); } OP_EPILOGUE;
 


### PR DESCRIPTION
Commit https://github.com/libretro/beetle-wswan-libretro/commit/cf41b0bda0f46f6643bc7aad09842a2ab5a0c126 broke the core. PR #60 fixed it.

Now commit https://github.com/libretro/beetle-wswan-libretro/commit/b631efbf08a09bb139461b17947c6a5309789820 has broken the same piece of code in exactly the same manner. This PR fixes it. Again.

Closes #76
Closes #75