### PR TITLE
Add optional 60Hz mode

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -182,6 +182,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "33"
    },
    {
+      "wswan_60hz_mode",
+      "60Hz Mode",
+      NULL,
+      "Update the display at 60Hz instead of the native 75Hz WonderSwan refresh rate by dropping every fifth frame. Reduces video smoothness, but avoids screen tearing on displays that do not support native operation above 60Hz.",
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled",
+   },
+   {
       "wswan_sound_sample_rate",
       "Sound Output Sample Rate",
       NULL,
@@ -193,9 +207,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "22050",  NULL },
          { "44100",  NULL },
          { "48000",  NULL },
-         { "96000",  NULL },
-         { "192000", NULL },
-         { "384000", NULL },
          { NULL, NULL },
       },
       "44100",

--- a/mednafen/wswan/sound.h
+++ b/mednafen/wswan/sound.h
@@ -13,7 +13,7 @@ void WSwan_SoundReset(void);
 
 bool WSwan_SetSoundRate(uint32 rate);
 
-int32 WSwan_SoundFlush(int16 *SoundBuf, const int32 MaxSoundFrames);
+int32 WSwan_SoundFlush(int16 **SoundBuf, int32 *SoundBufSize);
 
 void WSwan_SoundKill(void);
 


### PR DESCRIPTION
At present the core runs at ~75Hz, matching the native refresh rate of the WonderSwan hardware. This is fine if the core is run on a VRR display (or one that natively supports 75Hz...), but on regular 60Hz panels it can cause issues. In particular, screen tearing is very likely to occur. I experience this on Linux (when not using a compositor and without vsync forced at the driver level) and on 3DS. The tearing is so bad on 3DS that I consider the core to be unusable on that platform...

This PR adds a new `60Hz Mode` core option, which can be used to force the core to run at 60Hz (actually 60.38Hz, but RetroArch handles this nicely via dynamic rate control). Note that the core still runs at the 'correct' speed when this option is enabled - internally, the core is running the nominal ~75 frames per second, but every 5th frame is 'dropped'. This reduces video smoothness, but then 75Hz on a 60Hz display is not smooth either. More importantly, enabling this option eliminates screen tearing.

In addition, this PR makes the following minor changes:

- The frontend reported framerate is now set correctly in 75Hz mode (previously this was truncated, leading to a slight tendency for the frontend audio buffer to under-run)
- The internal audio samples buffer has been reduced from a ~64kb (!) static array to a tiny, dynamically created array of just the correct size
- On 3DS, the video buffers are now allocated in linear memory (for improved performance)
- The `96000`, `192000` and `384000` audio sample rate options have been removed, because they are nonsensical and harm AV synchronisation
- Several pieces of dead code have been removed