### PR TITLE
Add optional low pass audio filter

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -211,6 +211,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       },
       "44100",
    },
+   {
+      "wswan_sound_low_pass",
+      "Audio Filter",
+      NULL,
+      "Apply a low pass audio filter to 'soften' the sometimes harsh chiptunes produced by the WonderSwan.",
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled",
+   },
    { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
 };
 


### PR DESCRIPTION
The WonderSwan has a tendency to produce rather harsh/abrasive chiptunes. This PR adds an optional low pass audio filter which softens and 'mellows out' the generated sound.